### PR TITLE
Bootstrap from empty data

### DIFF
--- a/serve.sh
+++ b/serve.sh
@@ -11,6 +11,9 @@ shutdown() {
 
 trap shutdown SIGTERM SIGINT
 
+if [[ $initialize = yes ]]; then
+  devpi-server --init
+fi
 # Need $DEVPI_SERVERDIR
 devpi-server --start --host 0.0.0.0 --port $DEVPI_PORT --theme $DEVPI_THEME
 


### PR DESCRIPTION
When start devpi from scratch (The directory `/devpi/server` is still empty), the follow error will raise:

```
user@host:~$ docker run --rm -it apihackers/devpi
fatal: The path '/devpi/server' contains no devpi-server data, use --init to initialize.
```

